### PR TITLE
fix: typescript-is is a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `typescript-is` is a runtime dependency
+
 ## [0.0.26] - 2021-07-30
 ### Added
 - Map and Profile AST validation with `typescript-is`

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "generate_schemas": "yarn run generate_profile_schema && yarn run generate_map_schema",
     "prepare": "husky install"
   },
+  "dependencies": {
+    "typescript-is": "^0.18.3"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
@@ -45,7 +48,6 @@
     "ts-node": "^10.1.0",
     "ttypescript": "^1.5.12",
     "typescript": "^4.3.5",
-    "typescript-is": "^0.18.3",
     "typescript-json-schema": "^0.50.1"
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
Move `typescript-is` into runtime dependencies

## Motivation and Context
`is` validators in `util` don't work in other packages because `typescript-is` is a runtime dependency but currently specified as a dev dependency
