### PR TITLE
fix: UseCaseSlotDefinitionNode generic to not extend Type

### DIFF
--- a/src/interfaces/ast/profile-ast.ts
+++ b/src/interfaces/ast/profile-ast.ts
@@ -180,7 +180,7 @@ export interface NamedModelDefinitionNode
  *
  * The point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation.
  */
-export interface UseCaseSlotDefinitionNode<T extends Type = Type>
+export interface UseCaseSlotDefinitionNode<T extends ProfileASTNode>
   extends ProfileASTNodeBase,
     DocumentedNode {
   kind: 'UseCaseSlotDefinition';
@@ -282,7 +282,8 @@ export type ProfileASTNode =
   | ProfileHeaderNode
   | UnionDefinitionNode
   | UseCaseDefinitionNode
-  | UseCaseSlotDefinitionNode
+  | UseCaseSlotDefinitionNode<Type>
+  | UseCaseSlotDefinitionNode<ComlinkLiteralNode>
   | UseCaseExampleNode
   | ComlinkPrimitiveLiteralNode
   | ComlinkObjectLiteralNode

--- a/src/interfaces/ast/profile-ast.utils.ts
+++ b/src/interfaces/ast/profile-ast.utils.ts
@@ -59,8 +59,8 @@ export const isUnionDefinitionNode: Guard<UnionDefinitionNode> =
   createIs<UnionDefinitionNode>();
 export const isUseCaseDefinitionNode: Guard<UseCaseDefinitionNode> =
   createIs<UseCaseDefinitionNode>();
-export const isUseCaseSlotDefinitionNode: Guard<UseCaseSlotDefinitionNode> =
-  createIs<UseCaseSlotDefinitionNode>();
+export const isUseCaseSlotDefinitionNode: Guard<UseCaseSlotDefinitionNode<ProfileASTNode>> =
+  createIs<UseCaseSlotDefinitionNode<ProfileASTNode>>();
 
 export const assertProfileDocumentNode: (node: unknown) => ProfileDocumentNode =
   createAssertEquals<ProfileDocumentNode>();


### PR DESCRIPTION
For some reason this did not error even though there is usage of `UseCaseSlotDefinitionNode<ComlinkLiteral>` in the type definitions. It does error when using it downstream though.
