### PR TITLE
Feature/enum value name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added guards and visit functions for `UseCaseExampleNode` and `ComlinkLiteralNode`
 - `serviceId` field to `HttpCallStatementNode`
+- `name` field to `EnumValueNode` containing the enum variant name
 
 ## [1.0.0] - 2021-11-04
 ### Added

--- a/src/interfaces/ast/profile-ast.schema.json
+++ b/src/interfaces/ast/profile-ast.schema.json
@@ -721,7 +721,6 @@
             },
             "required": [
                 "kind",
-                "name",
                 "value"
             ],
             "type": "object"

--- a/src/interfaces/ast/profile-ast.schema.json
+++ b/src/interfaces/ast/profile-ast.schema.json
@@ -708,6 +708,9 @@
                     ],
                     "type": "object"
                 },
+                "name": {
+                    "type": "string"
+                },
                 "value": {
                     "type": [
                         "string",
@@ -718,6 +721,7 @@
             },
             "required": [
                 "kind",
+                "name",
                 "value"
             ],
             "type": "object"

--- a/src/interfaces/ast/profile-ast.ts
+++ b/src/interfaces/ast/profile-ast.ts
@@ -115,7 +115,7 @@ export type Type = TypeName | TypeDefinition;
  */
 export interface EnumValueNode extends ProfileASTNodeBase, DocumentedNode {
   kind: 'EnumValue';
-  name: string;
+  name?: string | undefined;
   value: string | number | boolean;
 }
 

--- a/src/interfaces/ast/profile-ast.ts
+++ b/src/interfaces/ast/profile-ast.ts
@@ -115,6 +115,7 @@ export type Type = TypeName | TypeDefinition;
  */
 export interface EnumValueNode extends ProfileASTNodeBase, DocumentedNode {
   kind: 'EnumValue';
+  name: string;
   value: string | number | boolean;
 }
 

--- a/src/interfaces/ast/profile-ast.utils.test.ts
+++ b/src/interfaces/ast/profile-ast.utils.test.ts
@@ -222,6 +222,7 @@ describe('profile-ast.utils', () => {
 
       const enumValueNode: EnumValueNode = {
         kind: 'EnumValue',
+        name: 'FOO',
         value: 1,
       };
       expect(isType(enumValueNode)).toEqual(false);
@@ -238,6 +239,7 @@ describe('profile-ast.utils', () => {
 
       const enumValueNode: EnumValueNode = {
         kind: 'EnumValue',
+        name: 'FOO',
         value: 1,
       };
       expect(isEnumValueNode(enumValueNode)).toEqual(true);


### PR DESCRIPTION
## Description
Adds `name` field to the `EnumValueNode` to preserve the original enum value/variant name.

## Motivation and Context
We want to keep information about the enum value/variant name even when its value is specified explicitly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
