### PR TITLE
feat: add simple retry policy config

### DIFF
--- a/src/interfaces/superjson/superjson.schema.json
+++ b/src/interfaces/superjson/superjson.schema.json
@@ -67,6 +67,29 @@
                                                                     {
                                                                         "additionalProperties": false,
                                                                         "properties": {
+                                                                            "kind": {
+                                                                                "enum": [
+                                                                                    "simple"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "maxContiguousRetries": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "requestTimeout": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "kind"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    {
+                                                                        "additionalProperties": false,
+                                                                        "properties": {
                                                                             "backoff": {
                                                                                 "anyOf": [
                                                                                     {
@@ -110,6 +133,10 @@
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
                                                                             },
+                                                                            "openTime": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
                                                                             "requestTimeout": {
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
@@ -123,7 +150,8 @@
                                                                     {
                                                                         "enum": [
                                                                             "circuit-breaker",
-                                                                            "none"
+                                                                            "none",
+                                                                            "simple"
                                                                         ],
                                                                         "type": "string"
                                                                     }
@@ -176,6 +204,29 @@
                                                                     {
                                                                         "additionalProperties": false,
                                                                         "properties": {
+                                                                            "kind": {
+                                                                                "enum": [
+                                                                                    "simple"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "maxContiguousRetries": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "requestTimeout": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "kind"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    {
+                                                                        "additionalProperties": false,
+                                                                        "properties": {
                                                                             "backoff": {
                                                                                 "anyOf": [
                                                                                     {
@@ -219,6 +270,10 @@
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
                                                                             },
+                                                                            "openTime": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
                                                                             "requestTimeout": {
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
@@ -232,7 +287,8 @@
                                                                     {
                                                                         "enum": [
                                                                             "circuit-breaker",
-                                                                            "none"
+                                                                            "none",
+                                                                            "simple"
                                                                         ],
                                                                         "type": "string"
                                                                     }
@@ -336,6 +392,29 @@
                                                                     {
                                                                         "additionalProperties": false,
                                                                         "properties": {
+                                                                            "kind": {
+                                                                                "enum": [
+                                                                                    "simple"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "maxContiguousRetries": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "requestTimeout": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "kind"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    {
+                                                                        "additionalProperties": false,
+                                                                        "properties": {
                                                                             "backoff": {
                                                                                 "anyOf": [
                                                                                     {
@@ -379,6 +458,10 @@
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
                                                                             },
+                                                                            "openTime": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
                                                                             "requestTimeout": {
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
@@ -392,7 +475,8 @@
                                                                     {
                                                                         "enum": [
                                                                             "circuit-breaker",
-                                                                            "none"
+                                                                            "none",
+                                                                            "simple"
                                                                         ],
                                                                         "type": "string"
                                                                     }
@@ -445,6 +529,29 @@
                                                                     {
                                                                         "additionalProperties": false,
                                                                         "properties": {
+                                                                            "kind": {
+                                                                                "enum": [
+                                                                                    "simple"
+                                                                                ],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "maxContiguousRetries": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "requestTimeout": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "kind"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    {
+                                                                        "additionalProperties": false,
+                                                                        "properties": {
                                                                             "backoff": {
                                                                                 "anyOf": [
                                                                                     {
@@ -488,6 +595,10 @@
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
                                                                             },
+                                                                            "openTime": {
+                                                                                "minimum": 0,
+                                                                                "type": "integer"
+                                                                            },
                                                                             "requestTimeout": {
                                                                                 "minimum": 0,
                                                                                 "type": "integer"
@@ -501,7 +612,8 @@
                                                                     {
                                                                         "enum": [
                                                                             "circuit-breaker",
-                                                                            "none"
+                                                                            "none",
+                                                                            "simple"
                                                                         ],
                                                                         "type": "string"
                                                                     }

--- a/src/interfaces/superjson/superjson.ts
+++ b/src/interfaces/superjson/superjson.ts
@@ -21,6 +21,7 @@ export type UriPath = string;
 // Retry policy
 export enum OnFail {
   NONE = 'none',
+  SIMPLE = 'simple',
   CIRCUIT_BREAKER = 'circuit-breaker',
 }
 
@@ -28,15 +29,45 @@ export enum BackoffKind {
   EXPONENTIAL = 'exponential',
 }
 
+export type BackoffPolicy =
+  | BackoffKind.EXPONENTIAL
+  | {
+      kind: BackoffKind.EXPONENTIAL;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      start?: number | undefined;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      factor?: number | undefined;
+    };
+
 /**
  * RetryPolicy per usecase values.
  */
 export type RetryPolicy =
   | OnFail.NONE
-  | OnFail.CIRCUIT_BREAKER
   | {
       kind: OnFail.NONE;
     }
+  | OnFail.SIMPLE
+  | {
+      kind: OnFail.SIMPLE;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      maxContiguousRetries?: number | undefined;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      requestTimeout?: number | undefined;
+    }
+  | OnFail.CIRCUIT_BREAKER
   | {
       kind: OnFail.CIRCUIT_BREAKER;
       /**
@@ -48,31 +79,35 @@ export type RetryPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
+      openTime?: number | undefined;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
       requestTimeout?: number | undefined;
-      backoff?:
-        | BackoffKind.EXPONENTIAL
-        | {
-            kind: BackoffKind.EXPONENTIAL;
-            /**
-             * @TJS-minimum 0
-             * @TJS-type integer
-             **/
-            start?: number | undefined;
-            /**
-             * @TJS-minimum 0
-             * @TJS-type integer
-             **/
-            factor?: number | undefined;
-          }
-        | undefined;
+      backoff?: BackoffPolicy | undefined;
     };
+
+export type NormalizedBackoffPolicy = {
+  kind: BackoffKind.EXPONENTIAL;
+  /**
+   * @TJS-minimum 0
+   * @TJS-type integer
+   **/
+  start?: number | undefined;
+  /**
+   * @TJS-minimum 0
+   * @TJS-type integer
+   **/
+  factor?: number | undefined;
+};
 
 export type NormalizedRetryPolicy =
   | {
       kind: OnFail.NONE;
     }
   | {
-      kind: OnFail.CIRCUIT_BREAKER;
+      kind: OnFail.SIMPLE;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
@@ -83,21 +118,25 @@ export type NormalizedRetryPolicy =
        * @TJS-type integer
        **/
       requestTimeout?: number | undefined;
-      backoff?:
-        | {
-            kind: BackoffKind.EXPONENTIAL;
-            /**
-             * @TJS-minimum 0
-             * @TJS-type integer
-             **/
-            start?: number | undefined;
-            /**
-             * @TJS-minimum 0
-             * @TJS-type integer
-             **/
-            factor?: number | undefined;
-          }
-        | undefined;
+    }
+  | {
+      kind: OnFail.CIRCUIT_BREAKER;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      maxContiguousRetries?: number | undefined;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      openTime?: number | undefined;
+      /**
+       * @TJS-minimum 0
+       * @TJS-type integer
+       **/
+      requestTimeout?: number | undefined;
+      backoff: NormalizedBackoffPolicy;
     };
 
 /**


### PR DESCRIPTION
Adds simple retry policy config to the superjson schema. Also adds `openTime` to circuit breaker policy (this makes it possible to emulate simple policy using circuit breaker policy).