### PR TITLE
chore: clean up oboslete `| undefined` from schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added simple retry policy configuration to superjson schema
+- Added `openTime` field to circuit breaker configuration in superjson schema
+
 ### Changed
 - removed `typescript-is` and replaced it with `ajv` validation
 - `isProfileDocumentNode` and `isMapDocumentNode` do full schema validation
+- Cleaned up schema types by removing now obsolete `| undefined`.
 
 ## [1.1.0] - 2022-01-19
 ### Added

--- a/src/interfaces/ast/map-ast.schema.json
+++ b/src/interfaces/ast/map-ast.schema.json
@@ -161,10 +161,12 @@
                     "type": "array"
                 },
                 "condition": {
-                    "$ref": "#/definitions/ConditionAtomNode"
+                    "$ref": "#/definitions/ConditionAtomNode",
+                    "description": "Statement condition atom: `if (<jessie>)`"
                 },
                 "iteration": {
-                    "$ref": "#/definitions/IterationAtomNode"
+                    "$ref": "#/definitions/IterationAtomNode",
+                    "description": "Iteration atom: `foreach (<iterationVariable> of <iterable>)`"
                 },
                 "kind": {
                     "enum": [
@@ -408,7 +410,8 @@
                     "type": "string"
                 },
                 "request": {
-                    "$ref": "#/definitions/HttpRequestNode"
+                    "$ref": "#/definitions/HttpRequestNode",
+                    "description": "Request definition for http:\n`request <?contentType> <?contentLanguage> { <?query> <?headers> <?body> }`"
                 },
                 "responseHandlers": {
                     "items": {
@@ -459,7 +462,8 @@
                     "type": "string"
                 },
                 "headers": {
-                    "$ref": "#/definitions/ObjectLiteralNode"
+                    "$ref": "#/definitions/ObjectLiteralNode",
+                    "description": "Object literal node: `{ <...assignments> }`"
                 },
                 "kind": {
                     "enum": [
@@ -527,7 +531,8 @@
                     "type": "object"
                 },
                 "query": {
-                    "$ref": "#/definitions/ObjectLiteralNode"
+                    "$ref": "#/definitions/ObjectLiteralNode",
+                    "description": "Object literal node: `{ <...assignments> }`"
                 },
                 "security": {
                     "items": {
@@ -672,10 +677,12 @@
                     "type": "array"
                 },
                 "condition": {
-                    "$ref": "#/definitions/ConditionAtomNode"
+                    "$ref": "#/definitions/ConditionAtomNode",
+                    "description": "Statement condition atom: `if (<jessie>)`"
                 },
                 "iteration": {
-                    "$ref": "#/definitions/IterationAtomNode"
+                    "$ref": "#/definitions/IterationAtomNode",
+                    "description": "Iteration atom: `foreach (<iterationVariable> of <iterable>)`"
                 },
                 "kind": {
                     "enum": [
@@ -1677,7 +1684,8 @@
             "description": "Outcome node, specifying what value to return and whether to terminate the flow immediately:\n`return/fail <?condition> <value>`\n`map result/error <?condition> <value>`",
             "properties": {
                 "condition": {
-                    "$ref": "#/definitions/ConditionAtomNode"
+                    "$ref": "#/definitions/ConditionAtomNode",
+                    "description": "Statement condition atom: `if (<jessie>)`"
                 },
                 "isError": {
                     "type": "boolean"
@@ -1856,7 +1864,8 @@
                     "type": "array"
                 },
                 "condition": {
-                    "$ref": "#/definitions/ConditionAtomNode"
+                    "$ref": "#/definitions/ConditionAtomNode",
+                    "description": "Statement condition atom: `if (<jessie>)`"
                 },
                 "kind": {
                     "enum": [

--- a/src/interfaces/ast/map-ast.ts
+++ b/src/interfaces/ast/map-ast.ts
@@ -26,7 +26,7 @@ export type MapNodeKind =
 
 export interface MapASTNodeBase {
   kind: MapNodeKind;
-  location?: LocationSpan | undefined;
+  location?: LocationSpan;
 }
 
 // ATOMS
@@ -53,8 +53,8 @@ export interface ObjectLiteralNode extends MapASTNodeBase {
 export interface JessieExpressionNode extends MapASTNodeBase {
   kind: 'JessieExpression';
   expression: string;
-  source?: string | undefined;
-  sourceMap?: string | undefined;
+  source?: string;
+  sourceMap?: string;
 }
 
 /**
@@ -62,8 +62,8 @@ export interface JessieExpressionNode extends MapASTNodeBase {
  */
 export interface InlineCallNode extends MapASTNodeBase {
   kind: 'InlineCall';
-  condition?: ConditionAtomNode | undefined;
-  iteration?: IterationAtomNode | undefined;
+  condition?: ConditionAtomNode;
+  iteration?: IterationAtomNode;
   operationName: string;
   arguments: AssignmentNode[];
 }
@@ -109,7 +109,7 @@ export interface IterationAtomNode extends MapASTNodeBase {
  */
 export interface OutcomeStatementNode extends MapASTNodeBase {
   kind: 'OutcomeStatement';
-  condition?: ConditionAtomNode | undefined;
+  condition?: ConditionAtomNode;
   isError: boolean;
   terminateFlow: boolean;
   value: LiteralNode;
@@ -122,7 +122,7 @@ export interface OutcomeStatementNode extends MapASTNodeBase {
  */
 export interface SetStatementNode extends MapASTNodeBase {
   kind: 'SetStatement';
-  condition?: ConditionAtomNode | undefined;
+  condition?: ConditionAtomNode;
   assignments: AssignmentNode[];
 }
 
@@ -131,8 +131,8 @@ export interface SetStatementNode extends MapASTNodeBase {
  */
 export interface CallStatementNode extends MapASTNodeBase {
   kind: 'CallStatement';
-  iteration?: IterationAtomNode | undefined;
-  condition?: ConditionAtomNode | undefined;
+  iteration?: IterationAtomNode;
+  condition?: ConditionAtomNode;
   operationName: string;
   arguments: AssignmentNode[];
   statements: (SetStatementNode | OutcomeStatementNode)[];
@@ -144,7 +144,7 @@ export interface CallStatementNode extends MapASTNodeBase {
 export type HttpSecurityRequirement = {
   id: string;
   /** Optional scheme information. */
-  scheme?: 'apikey' | 'basic' | 'bearer' | undefined;
+  scheme?: 'apikey' | 'basic' | 'bearer';
 };
 
 /**
@@ -153,11 +153,11 @@ export type HttpSecurityRequirement = {
  */
 export interface HttpRequestNode extends MapASTNodeBase {
   kind: 'HttpRequest';
-  contentType?: string | undefined;
-  contentLanguage?: string | undefined;
-  query?: ObjectLiteralNode | undefined;
-  headers?: ObjectLiteralNode | undefined;
-  body?: LiteralNode | undefined;
+  contentType?: string;
+  contentLanguage?: string;
+  query?: ObjectLiteralNode;
+  headers?: ObjectLiteralNode;
+  body?: LiteralNode;
   security: HttpSecurityRequirement[];
 }
 
@@ -171,9 +171,9 @@ export interface HttpResponseHandlerNode extends MapASTNodeBase {
    * @TJS-minimum 200
    * @TJS-maximum 599
    **/
-  statusCode?: number | undefined;
-  contentType?: string | undefined;
-  contentLanguage?: string | undefined;
+  statusCode?: number;
+  contentType?: string;
+  contentLanguage?: string;
   statements: (SetStatementNode | OutcomeStatementNode)[];
 }
 
@@ -183,12 +183,12 @@ export interface HttpResponseHandlerNode extends MapASTNodeBase {
 export interface HttpCallStatementNode extends MapASTNodeBase {
   kind: 'HttpCallStatement';
   method: string;
-  serviceId?: string | undefined;
+  serviceId?: string;
   /**
    * @format uri-reference
    **/
   url: string;
-  request?: HttpRequestNode | undefined;
+  request?: HttpRequestNode;
   responseHandlers: HttpResponseHandlerNode[];
 }
 
@@ -244,7 +244,7 @@ export interface MapHeaderNode extends MapASTNodeBase, DocumentedNode {
     /**
      * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
      **/
-    scope?: string | undefined;
+    scope?: string;
     /**
      * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
      **/
@@ -264,11 +264,11 @@ export interface MapHeaderNode extends MapASTNodeBase, DocumentedNode {
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      patch?: number | undefined;
+      patch?: number;
       /**
        * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
        **/
-      label?: string | undefined;
+      label?: string;
     };
   };
 
@@ -279,7 +279,7 @@ export interface MapHeaderNode extends MapASTNodeBase, DocumentedNode {
   /**
    * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
    **/
-  variant?: string | undefined;
+  variant?: string;
 }
 
 /**

--- a/src/interfaces/ast/profile-ast.schema.json
+++ b/src/interfaces/ast/profile-ast.schema.json
@@ -2162,7 +2162,8 @@
             "description": "Construct of form:\n```\nusecase ident safety {\ninput {\n  ...fields\n}\nresult type\nasync result type\nerror type\n}\n```",
             "properties": {
                 "asyncResult": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "documentation": {
                     "additionalProperties": false,
@@ -2239,7 +2240,8 @@
                     "type": "object"
                 },
                 "error": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "examples": {
                     "items": {
@@ -2248,7 +2250,8 @@
                     "type": "array"
                 },
                 "input": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ObjectDefinitionNode>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ObjectDefinitionNode>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "kind": {
                     "enum": [
@@ -2316,7 +2319,8 @@
                     "type": "object"
                 },
                 "result": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<Type>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "safety": {
                     "description": "Usecase safety indicator",
@@ -2343,16 +2347,19 @@
             "description": "Construct of form: `example <?name> {\n  <?input> { ... }\n  <?result> { ... }\n  <?error> { ... }\n}`",
             "properties": {
                 "asyncResult": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "error": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "exampleName": {
                     "type": "string"
                 },
                 "input": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "kind": {
                     "enum": [
@@ -2420,7 +2427,8 @@
                     "type": "object"
                 },
                 "result": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>"
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>",
+                    "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 }
             },
             "required": [

--- a/src/interfaces/ast/profile-ast.ts
+++ b/src/interfaces/ast/profile-ast.ts
@@ -33,7 +33,7 @@ export type ProfileNodeKind =
 export interface ProfileASTNodeBase {
   kind: ProfileNodeKind;
   // Stripped during transfer, but provided during parsing
-  location?: LocationSpan | undefined;
+  location?: LocationSpan;
 }
 
 // TYPES //
@@ -126,7 +126,7 @@ export type Type = TypeName | TypeDefinition;
  */
 export interface EnumValueNode extends ProfileASTNodeBase, DocumentedNode {
   kind: 'EnumValue';
-  name?: string | undefined;
+  name?: string;
   value: string | number | boolean;
 }
 
@@ -143,7 +143,7 @@ export interface FieldDefinitionNode
   fieldName: string;
   /** Non-required fields don't have to be present at all */
   required: boolean;
-  type?: Type | undefined;
+  type?: Type;
 }
 
 /**
@@ -160,7 +160,7 @@ export interface NamedFieldDefinitionNode
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
    **/
   fieldName: string;
-  type?: Type | undefined;
+  type?: Type;
 }
 
 // MODEL //
@@ -181,7 +181,7 @@ export interface NamedModelDefinitionNode
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
    **/
   modelName: string;
-  type?: Type | undefined;
+  type?: Type;
 }
 
 // USECASE //
@@ -220,12 +220,12 @@ export interface UseCaseDefinitionNode
    **/
   useCaseName: string;
   /** Usecase safety indicator */
-  safety?: 'safe' | 'unsafe' | 'idempotent' | undefined;
-  input?: UseCaseSlotDefinitionNode<ObjectDefinitionNode> | undefined;
-  result?: UseCaseSlotDefinitionNode<Type> | undefined;
-  asyncResult?: UseCaseSlotDefinitionNode<Type> | undefined;
-  error?: UseCaseSlotDefinitionNode<Type> | undefined;
-  examples?: UseCaseSlotDefinitionNode<UseCaseExampleNode>[] | undefined;
+  safety?: 'safe' | 'unsafe' | 'idempotent';
+  input?: UseCaseSlotDefinitionNode<ObjectDefinitionNode>;
+  result?: UseCaseSlotDefinitionNode<Type>;
+  asyncResult?: UseCaseSlotDefinitionNode<Type>;
+  error?: UseCaseSlotDefinitionNode<Type>;
+  examples?: UseCaseSlotDefinitionNode<UseCaseExampleNode>[];
 }
 
 // DOCUMENT //
@@ -238,7 +238,7 @@ export interface ProfileHeaderNode extends ProfileASTNodeBase, DocumentedNode {
   /**
    * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
    **/
-  scope?: string | undefined;
+  scope?: string;
   /**
    * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
    **/
@@ -262,7 +262,7 @@ export interface ProfileHeaderNode extends ProfileASTNodeBase, DocumentedNode {
     /**
      * @pattern require('./utils').DOCUMENT_NAME_RE_SOURCE
      **/
-    label?: string | undefined;
+    label?: string;
   };
 }
 
@@ -316,10 +316,10 @@ export type ProfileASTNode =
 export interface UseCaseExampleNode extends ProfileASTNodeBase {
   kind: 'UseCaseExample';
   exampleName?: string;
-  input?: UseCaseSlotDefinitionNode<ComlinkLiteralNode> | undefined;
-  result?: UseCaseSlotDefinitionNode<ComlinkLiteralNode> | undefined;
-  asyncResult?: UseCaseSlotDefinitionNode<ComlinkLiteralNode> | undefined;
-  error?: UseCaseSlotDefinitionNode<ComlinkLiteralNode> | undefined;
+  input?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
+  result?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
+  asyncResult?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
+  error?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
 }
 
 /**

--- a/src/interfaces/ast/source.ts
+++ b/src/interfaces/ast/source.ts
@@ -22,13 +22,11 @@ export type LocationSpan = {
 
 /** Node preceded by documenting string literal */
 export interface DocumentedNode {
-  documentation?:
-    | {
-        title: string;
-        description?: string | undefined;
-        location?: LocationSpan | undefined;
-      }
-    | undefined;
+  documentation?: {
+    title: string;
+    description?: string;
+    location?: LocationSpan;
+  };
 }
 
 /**
@@ -40,13 +38,13 @@ export interface AstMetadata {
     major: number;
     minor: number;
     patch: number;
-    label?: string | undefined;
+    label?: string;
   };
   parserVersion: {
     major: number;
     minor: number;
     patch: number;
-    label?: string | undefined;
+    label?: string;
   };
   sourceChecksum: string;
 }

--- a/src/interfaces/providerjson/providerjson.ts
+++ b/src/interfaces/providerjson/providerjson.ts
@@ -37,7 +37,7 @@ export type ApiKeySecurityScheme = {
    * @$ref ApiKeyPlacement
    */
   in: ApiKeyPlacement;
-  name?: string | undefined;
+  name?: string;
 };
 
 /**
@@ -58,7 +58,7 @@ export type BearerTokenSecurityScheme = {
   id: string;
   type: SecurityType.HTTP;
   scheme: HttpScheme.BEARER;
-  bearerFormat?: string | undefined;
+  bearerFormat?: string;
 };
 
 /**
@@ -72,15 +72,15 @@ export type DigestSecurityScheme = {
   /**
    * Code that should be returned from initial call for challenge eg. 401
    */
-  statusCode?: number | undefined;
+  statusCode?: number;
   /**
    * Name of header containing challenge from the server eg. www-authenticate
    */
-  challengeHeader?: string | undefined;
+  challengeHeader?: string;
   /**
    * Name of header containing authorization eg. Authorization
    */
-  authorizationHeader?: string | undefined;
+  authorizationHeader?: string;
 };
 
 /**
@@ -105,8 +105,8 @@ export type IntegrationParameter = {
    * @pattern require('../ast/utils').IDENTIFIER_RE_SOURCE
    */
   name: string;
-  description?: string | undefined;
-  default?: string | undefined;
+  description?: string;
+  default?: string;
 };
 
 /**
@@ -119,7 +119,7 @@ export type ProviderJson = {
    */
   name: string;
   services: ProviderService[];
-  securitySchemes?: SecurityScheme[] | undefined;
+  securitySchemes?: SecurityScheme[];
   defaultService: string;
-  parameters?: IntegrationParameter[] | undefined;
+  parameters?: IntegrationParameter[];
 };

--- a/src/interfaces/superjson/superjson.schema.json
+++ b/src/interfaces/superjson/superjson.schema.json
@@ -155,7 +155,8 @@
                                                                         ],
                                                                         "type": "string"
                                                                     }
-                                                                ]
+                                                                ],
+                                                                "description": "Retry policy configuration."
                                                             }
                                                         },
                                                         "type": "object"
@@ -292,7 +293,8 @@
                                                                         ],
                                                                         "type": "string"
                                                                     }
-                                                                ]
+                                                                ],
+                                                                "description": "Retry policy configuration."
                                                             }
                                                         },
                                                         "type": "object"
@@ -480,7 +482,8 @@
                                                                         ],
                                                                         "type": "string"
                                                                     }
-                                                                ]
+                                                                ],
+                                                                "description": "Retry policy configuration."
                                                             }
                                                         },
                                                         "type": "object"
@@ -617,7 +620,8 @@
                                                                         ],
                                                                         "type": "string"
                                                                     }
-                                                                ]
+                                                                ],
+                                                                "description": "Retry policy configuration."
                                                             }
                                                         },
                                                         "type": "object"

--- a/src/interfaces/superjson/superjson.ts
+++ b/src/interfaces/superjson/superjson.ts
@@ -37,16 +37,16 @@ export type BackoffPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      start?: number | undefined;
+      start?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      factor?: number | undefined;
+      factor?: number;
     };
 
 /**
- * RetryPolicy per usecase values.
+ * Retry policy configuration.
  */
 export type RetryPolicy =
   | OnFail.NONE
@@ -60,12 +60,12 @@ export type RetryPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      maxContiguousRetries?: number | undefined;
+      maxContiguousRetries?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      requestTimeout?: number | undefined;
+      requestTimeout?: number;
     }
   | OnFail.CIRCUIT_BREAKER
   | {
@@ -74,18 +74,18 @@ export type RetryPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      maxContiguousRetries?: number | undefined;
+      maxContiguousRetries?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      openTime?: number | undefined;
+      openTime?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      requestTimeout?: number | undefined;
-      backoff?: BackoffPolicy | undefined;
+      requestTimeout?: number;
+      backoff?: BackoffPolicy;
     };
 
 export type NormalizedBackoffPolicy = {
@@ -94,12 +94,12 @@ export type NormalizedBackoffPolicy = {
    * @TJS-minimum 0
    * @TJS-type integer
    **/
-  start?: number | undefined;
+  start?: number;
   /**
    * @TJS-minimum 0
    * @TJS-type integer
    **/
-  factor?: number | undefined;
+  factor?: number;
 };
 
 export type NormalizedRetryPolicy =
@@ -112,12 +112,12 @@ export type NormalizedRetryPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      maxContiguousRetries?: number | undefined;
+      maxContiguousRetries?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      requestTimeout?: number | undefined;
+      requestTimeout?: number;
     }
   | {
       kind: OnFail.CIRCUIT_BREAKER;
@@ -125,17 +125,17 @@ export type NormalizedRetryPolicy =
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      maxContiguousRetries?: number | undefined;
+      maxContiguousRetries?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      openTime?: number | undefined;
+      openTime?: number;
       /**
        * @TJS-minimum 0
        * @TJS-type integer
        **/
-      requestTimeout?: number | undefined;
+      requestTimeout?: number;
       backoff: NormalizedBackoffPolicy;
     };
 
@@ -144,8 +144,8 @@ export type NormalizedRetryPolicy =
  */
 export type UsecaseDefaults = {
   [usecase: string]: {
-    input?: { [key: string]: unknown } | undefined;
-    providerFailover?: boolean | undefined;
+    input?: { [key: string]: unknown };
+    providerFailover?: boolean;
   };
 };
 
@@ -161,8 +161,8 @@ export type NormalizedUsecaseDefaults = {
  */
 export type ProfileProviderDefaults = {
   [provider: string]: {
-    input?: { [key: string]: unknown } | undefined;
-    retryPolicy?: RetryPolicy | undefined;
+    input?: { [key: string]: unknown };
+    retryPolicy?: RetryPolicy;
   };
 };
 
@@ -177,14 +177,14 @@ export type NormalizedProfileProviderDefaults = {
  * Provider settings for specific profile.
  */
 export type ProfileProviderSettings = {
-  defaults?: ProfileProviderDefaults | undefined;
+  defaults?: ProfileProviderDefaults;
 } & (
   | {
       file: string;
     }
   | {
-      mapVariant?: string | undefined;
-      mapRevision?: string | undefined;
+      mapVariant?: string;
+      mapRevision?: string;
     }
 );
 
@@ -194,8 +194,8 @@ export type NormalizedProfileProviderSettings =
       defaults: NormalizedProfileProviderDefaults;
     }
   | {
-      mapVariant?: string | undefined;
-      mapRevision?: string | undefined;
+      mapVariant?: string;
+      mapRevision?: string;
       defaults: NormalizedProfileProviderDefaults;
     };
 
@@ -208,11 +208,9 @@ export type ProfileProviderEntry = UriPath | ProfileProviderSettings;
  * Expanded profile settings for one profile id.
  */
 export type ProfileSettings = {
-  priority?: string[] | undefined;
-  defaults?: UsecaseDefaults | undefined;
-  providers?:
-    | { [provider: string]: UriPath | ProfileProviderEntry }
-    | undefined;
+  priority?: string[];
+  defaults?: UsecaseDefaults;
+  providers?: { [provider: string]: UriPath | ProfileProviderEntry };
 } & (
   | {
       version: SemanticVersion;
@@ -291,13 +289,13 @@ export type SecurityValues =
  * Expanded provider settings for one provider name.
  */
 export type ProviderSettings = {
-  file?: string | undefined;
-  security?: SecurityValues[] | undefined;
-  parameters?: { [key: string]: string } | undefined;
+  file?: string;
+  security?: SecurityValues[];
+  parameters?: { [key: string]: string };
 };
 
 export type NormalizedProviderSettings = {
-  file?: string | undefined;
+  file?: string;
   security: SecurityValues[];
   parameters: { [key: string]: string };
 };
@@ -305,8 +303,8 @@ export type NormalizedProviderSettings = {
 export type ProviderEntry = UriPath | ProviderSettings;
 
 export type SuperJsonDocument = {
-  profiles?: { [profile: string]: ProfileEntry } | undefined;
-  providers?: { [provider: string]: ProviderEntry } | undefined;
+  profiles?: { [profile: string]: ProfileEntry };
+  providers?: { [provider: string]: ProviderEntry };
 };
 
 export type NormalizedSuperJsonDocument = {
@@ -321,7 +319,7 @@ export type AnonymizedSuperJsonDocument = {
       version: SemanticVersion | 'file';
       providers: {
         provider: string;
-        priority?: number | undefined;
+        priority?: number;
         version: SemanticVersion | 'file';
       }[];
     }


### PR DESCRIPTION
## Description
Cleans up obsolete `| undefined` from optional properties in schema. Also updates a forgotten changelog entry.

It appears that some documentation now propagates differently in the generated schemas, but otherwise there are no differences.

## Motivation and Context
Previously the valdiator generator we used was broken and required `| undefined` for optional properties to correctly validate. Now we use ajv and it doesn't require that anymore, so it can be removed to clean up the code.
