### PR TITLE
chore: fix AssertionError detailed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - removed `typescript-is` and replaced it with `ajv` validation
 - `isProfileDocumentNode` and `isMapDocumentNode` do full schema validation
 
+### Fixed
+- Fixed `AssertionError::detailed` message spreading an already-string message
+
 ## [1.1.0] - 2022-01-19
 ### Added
 - Added guards and visit functions for `UseCaseExampleNode` and `ComlinkLiteralNode`

--- a/src/error.ts
+++ b/src/error.ts
@@ -20,7 +20,7 @@ export class AssertionError extends Error {
   detailed(): string {
     return [
       'Found errors:',
-      ...this.message,
+      this.message,
       'Validated data:',
       JSON.stringify(this.data, undefined, 2),
     ].join('\n');


### PR DESCRIPTION
Small fix, the `this.message` is already a formatted string and does not need to be spread.