### PR TITLE
Input in examples can be only ObjectLiteral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+
+workdir/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `UseCaseExampleNode` input to be only `ComlinkObjectLiteralNode`
+
 ## [1.3.0] - 2023-01-31
 ### Added
 - Added `ComlinkNoneLiteral` to Profile AST

--- a/src/interfaces/ast/profile-ast.ts
+++ b/src/interfaces/ast/profile-ast.ts
@@ -95,10 +95,10 @@ export interface NonNullDefinitionNode extends ProfileASTNodeBase {
   kind: 'NonNullDefinition';
   // Should be `Exclude<Type, NonNullDefinitionNode | UnionDefinitionNode>` but it produces a TS(2502) error
   type:
-    | TypeName
-    | ObjectDefinitionNode
-    | EnumDefinitionNode
-    | ListDefinitionNode;
+  | TypeName
+  | ObjectDefinitionNode
+  | EnumDefinitionNode
+  | ListDefinitionNode;
 }
 
 /**
@@ -136,7 +136,7 @@ export interface EnumValueNode extends ProfileASTNodeBase, DocumentedNode {
  */
 export interface FieldDefinitionNode
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'FieldDefinition';
   /**
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
@@ -155,7 +155,7 @@ export interface FieldDefinitionNode
  */
 export interface NamedFieldDefinitionNode
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'NamedFieldDefinition';
   /**
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
@@ -176,7 +176,7 @@ export interface NamedFieldDefinitionNode
  */
 export interface NamedModelDefinitionNode
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'NamedModelDefinition';
   /**
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
@@ -194,7 +194,7 @@ export interface NamedModelDefinitionNode
  */
 export interface UseCaseSlotDefinitionNode<T extends ProfileASTNode>
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'UseCaseSlotDefinition';
   value: T;
 }
@@ -214,7 +214,7 @@ usecase ident safety {
 */
 export interface UseCaseDefinitionNode
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'UseCaseDefinition';
   /**
    * @pattern require('./utils').IDENTIFIER_RE_SOURCE
@@ -318,7 +318,7 @@ export type ProfileASTNode =
 export interface UseCaseExampleNode extends ProfileASTNodeBase {
   kind: 'UseCaseExample';
   exampleName?: string;
-  input?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
+  input?: UseCaseSlotDefinitionNode<ComlinkObjectLiteralNode>;
   result?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
   asyncResult?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
   error?: UseCaseSlotDefinitionNode<ComlinkLiteralNode>;
@@ -360,7 +360,7 @@ export interface ComlinkListLiteralNode extends ProfileASTNodeBase {
  */
 export interface ComlinkAssignmentNode
   extends ProfileASTNodeBase,
-    DocumentedNode {
+  DocumentedNode {
   kind: 'ComlinkAssignment';
   key: string[];
   value: ComlinkLiteralNode;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Example input can be only `ComlinkObjectLiteralNode` or input can be undefined.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

AST allowed to define example input which isn't possible to use for actual input. Eg. it allowed to use primitive as input.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
