### PR TITLE
Regenerate profile ast json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Profile AST JSON Schema regenerated
 
 ## [1.3.1] - 2023-07-18
 ### Fixed

--- a/src/interfaces/ast/profile-ast.schema.json
+++ b/src/interfaces/ast/profile-ast.schema.json
@@ -2452,7 +2452,7 @@
                     "type": "string"
                 },
                 "input": {
-                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkLiteralNode>",
+                    "$ref": "#/definitions/UseCaseSlotDefinitionNode<ComlinkObjectLiteralNode>",
                     "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation."
                 },
                 "kind": {
@@ -2675,6 +2675,159 @@
                 },
                 "value": {
                     "$ref": "#/definitions/ComlinkLiteralNode"
+                }
+            },
+            "required": [
+                "kind",
+                "value"
+            ],
+            "type": "object"
+        },
+        "UseCaseSlotDefinitionNode<ComlinkObjectLiteralNode>": {
+            "additionalProperties": false,
+            "description": "Named slot definition for usecases and usecase examples.\n\nThe point of this node is so that the usecase slots (`input`, `result`, `async result` and `error`) can have proper spans and documentation.",
+            "properties": {
+                "documentation": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "additionalProperties": false,
+                            "description": "Location span within the source.",
+                            "properties": {
+                                "end": {
+                                    "additionalProperties": false,
+                                    "description": "Location within the source.\n\nContains both the human-readable line:column information and character index.",
+                                    "properties": {
+                                        "charIndex": {
+                                            "description": "Character index within the source code - starts at 0",
+                                            "type": "number"
+                                        },
+                                        "column": {
+                                            "description": "Column number - starts at 1",
+                                            "type": "number"
+                                        },
+                                        "line": {
+                                            "description": "Line number - starts at 1",
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "charIndex",
+                                        "column",
+                                        "line"
+                                    ],
+                                    "type": "object"
+                                },
+                                "start": {
+                                    "additionalProperties": false,
+                                    "description": "Location within the source.\n\nContains both the human-readable line:column information and character index.",
+                                    "properties": {
+                                        "charIndex": {
+                                            "description": "Character index within the source code - starts at 0",
+                                            "type": "number"
+                                        },
+                                        "column": {
+                                            "description": "Column number - starts at 1",
+                                            "type": "number"
+                                        },
+                                        "line": {
+                                            "description": "Line number - starts at 1",
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "charIndex",
+                                        "column",
+                                        "line"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "required": [
+                                "end",
+                                "start"
+                            ],
+                            "type": "object"
+                        },
+                        "title": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "title"
+                    ],
+                    "type": "object"
+                },
+                "kind": {
+                    "enum": [
+                        "UseCaseSlotDefinition"
+                    ],
+                    "type": "string"
+                },
+                "location": {
+                    "additionalProperties": false,
+                    "description": "Location span within the source.",
+                    "properties": {
+                        "end": {
+                            "additionalProperties": false,
+                            "description": "Location within the source.\n\nContains both the human-readable line:column information and character index.",
+                            "properties": {
+                                "charIndex": {
+                                    "description": "Character index within the source code - starts at 0",
+                                    "type": "number"
+                                },
+                                "column": {
+                                    "description": "Column number - starts at 1",
+                                    "type": "number"
+                                },
+                                "line": {
+                                    "description": "Line number - starts at 1",
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "charIndex",
+                                "column",
+                                "line"
+                            ],
+                            "type": "object"
+                        },
+                        "start": {
+                            "additionalProperties": false,
+                            "description": "Location within the source.\n\nContains both the human-readable line:column information and character index.",
+                            "properties": {
+                                "charIndex": {
+                                    "description": "Character index within the source code - starts at 0",
+                                    "type": "number"
+                                },
+                                "column": {
+                                    "description": "Column number - starts at 1",
+                                    "type": "number"
+                                },
+                                "line": {
+                                    "description": "Line number - starts at 1",
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "charIndex",
+                                "column",
+                                "line"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "end",
+                        "start"
+                    ],
+                    "type": "object"
+                },
+                "value": {
+                    "$ref": "#/definitions/ComlinkObjectLiteralNode"
                 }
             },
             "required": [


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
## Description
<!--- Describe your changes in detail -->

Generated JSON schema from typescript for Profile ast. Which was forgotten in https://github.com/superfaceai/ast-js/pull/102

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
